### PR TITLE
Add NETSNMP_INSTALL option, update Perl version, add File-Slurp and JSON-XS modules

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,10 +1,12 @@
 FROM alpine:3.8
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN apk --no-cache add build-base gmp-dev zlib-dev gdbm-dev db-dev readline-dev libffi-dev coreutils yaml-dev linux-headers autoconf
 RUN apk --no-cache add openssh-client openssl openssl-dev expat-dev
@@ -23,11 +25,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   PATH=/opt/perl/bin:${PATH} cpanm --force --notest ${CPAN_MODULES} && \
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_alpine_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)alpine_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/Dockerfile.alpine3.8
+++ b/Dockerfile.alpine3.8
@@ -1,10 +1,12 @@
 FROM alpine:3.8
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN apk --no-cache add build-base gmp-dev zlib-dev gdbm-dev db-dev readline-dev libffi-dev coreutils yaml-dev linux-headers autoconf
 RUN apk --no-cache add openssh-client openssl openssl-dev expat-dev
@@ -23,11 +25,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   PATH=/opt/perl/bin:${PATH} cpanm --force --notest ${CPAN_MODULES} && \
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_alpine3.8_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)alpine_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -1,11 +1,13 @@
 FROM centos:6
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel
 
@@ -22,11 +24,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm && \
   yum clean all
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_centos6_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)$(source /etc/os-release && echo $ID$VERSION_ID)_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,11 +1,13 @@
 FROM centos:7
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel
 
@@ -22,11 +24,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm && \
   yum clean all
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$(source /etc/os-release && echo $ID$VERSION_ID)_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)$(source /etc/os-release && echo $ID$VERSION_ID)_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/Dockerfile.centos8
+++ b/Dockerfile.centos8
@@ -1,11 +1,13 @@
 FROM centos:8
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel
 
@@ -22,11 +24,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm && \
   yum clean all
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$(source /etc/os-release && echo $ID$VERSION_ID)_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)$(source /etc/os-release && echo $ID$VERSION_ID)_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -1,11 +1,13 @@
 FROM debian:9
 
-ARG PERL_VERSION=5.30.1
+ARG PERL_VERSION=5.34.0
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
-ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper"
+ARG CPAN_MODULES="DBI JSON LWP LWP::UserAgent LWP::Protocol::https XML::LibXML Text::CSV IO::Socket::SSL Time::Zone HTTP::Response Net::SMTP WWW::Mechanize DateTime Test::Simple Net::SNMP AutoLoader Getopt::Long IO::File Module::Load File::Basename Digest::MD5 Data::Dumper File::Slurp JSON::XS"
 ARG MAKE_TEST_CMD="make test"
 ARG CPANM_TEST_FLAG=""
+ARG NETSNMP_INSTALL=false
+ARG NETSNMP_VERSION=5.9.1
 
 RUN apt-get update && apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev
 
@@ -22,11 +24,20 @@ RUN curl -s -L https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz -o perl-
   rm -rf /opt/perl/man /perl-${PERL_VERSION}.tar.gz /perl-${PERL_VERSION} /root/.cpanm && \
   apt-get clean
 
+RUN if [ $NETSNMP_INSTALL == "true" ]; then curl -s -L https://sourceforge.net/projects/net-snmp/files/net-snmp/${NETSNMP_VERSION}/net-snmp-${NETSNMP_VERSION}.tar.gz -o net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  tar xzf net-snmp-${NETSNMP_VERSION}.tar.gz && \
+  cd net-snmp-${NETSNMP_VERSION} && \
+  env PERLPROG=/opt/perl/bin/perl sh ./configure --prefix=/opt/perl --with-perl-modules --with-default-snmp-version="2" --disable-embedded-perl --disable-snmptrapd-subagent --disable-manuals --disable-agent --disable-scripts && \
+  make && \
+  make install && \
+  rm -rf /net-snmp-${NETSNMP_VERSION}.tar.gz /net-snmp-${NETSNMP_VERSION} \
+  ; fi
+
 RUN LIBS=$(find /opt/perl -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/perl/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_debian9_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-perl-runtime_${ASSET_VERSION}_perl-${PERL_VERSION}_$([[ $NETSNMP_INSTALL == "true" ]] && echo net-snmp-${NETSNMP_VERSION}_)debian9_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /opt/perl/ . && \
   ls -l $SENSU_ASSET
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ The following modules (and their dependencies) are packaged as part of the runti
 * DateTime
 * Digest::MD5
 * File::Basename
+* File::Slurp
 * Getopt::Long
 * HTTP::Response
 * IO::File
 * IO::Socket::SSL
 * JSON
+* JSON::XS
 * LWP
 * LWP::Protocol::https
 * LWP::UserAgent
@@ -69,23 +71,35 @@ Please note the following instructions:
 
 1. Use a Docker container to build Perl, and generate a local_build Sensu Go Asset.
 
+   Without NET-SNMP:
    ```
-   $ docker build --build-arg "PERL_VERSION=5.30.1" -t sensu-perl-runtime:5.30.1-debian -f Dockerfile.debian .
+   $ docker build --build-arg "PERL_VERSION=5.34.0" -t sensu-perl-runtime:5.34.0-debian -f Dockerfile.debian .
+   ```
+   With NET-SNMP:
+   ```
+   $ docker build --build-arg "PERL_VERSION=5.34.0" --build-arg "NETSNMP_INSTALL=true" --build-arg "NETSNMP_VERSION=5.9.1" -t sensu-perl-runtime:5.34.0-net-snmp-5.9.1-debian -f Dockerfile.debian .
    ```
 
 2. Extract your new sensu-perl asset, and get the SHA-512 hash for your Sensu asset!
 
+   Without NET-SNMP:
    ```
    $ mkdir dist
-   $ docker run -v "$PWD/dist:/dist" sensu-perl-runtime:5.30.1-debian cp /assets/sensu-perl-runtime_local-build_perl-5.30.1_debian_linux_amd64.tar.gz /dist/
-   $ shasum -a 512 dist/sensu-perl-runtime_local-build_perl-5.30.1_debian_linux_amd64.tar.gz
+   $ docker run -v "$PWD/dist:/dist" sensu-perl-runtime:5.34.0-debian cp /assets/sensu-perl-runtime_local-build_perl-5.34.0_debian_linux_amd64.tar.gz /dist/
+   $ shasum -a 512 dist/sensu-perl-*
+   ```
+   With NET-SNMP:
+   ```
+   $ mkdir dist
+   $ docker run -v "$PWD/dist:/dist" sensu-perl-runtime:5.34.0-net-snmp-5.9.1-debian bash -c "cp /assets/sensu-perl-runtime* /dist/"
+   $ shasum -a 512 dist/sensu-perl-*
    ```
 
 3. Put that asset somewhere that your Sensu agent can fetch it. Perhaps add it to the Bonsai asset index!
 
 4. Create an asset resource in Sensu Go.
 
-   First, create a configuration file called `sensu-perl-runtime-5.30.1-debian.json` with
+   First, create a configuration file called `sensu-perl-runtime-5.34.0-debian.json` with
    the following contents:
 
    ```
@@ -93,13 +107,13 @@ Please note the following instructions:
      "type": "Asset",
      "api_version": "core/v2",
      "metadata": {
-       "name": "sensu-ruby-runtime-5.30.1-debian",
+       "name": "sensu-ruby-runtime-5.34.0-debian",
        "namespace": "default",
        "labels": {},
        "annotations": {}
      },
      "spec": {
-       "url": "http://your-asset-server-here/assets/sensu-perl_local-build_perl-5.30.1_debian_linux_amd64.tar.gz",
+       "url": "http://your-asset-server-here/assets/sensu-perl_local-build_perl-5.34.0_debian_linux_amd64.tar.gz",
        "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
        "filters": [
          "entity.system.os == 'linux'",
@@ -113,7 +127,7 @@ Please note the following instructions:
    Then create the asset via:
 
    ```
-   $ sensuctl create -f sensu-perl-runtime-5.30.1-debian.json
+   $ sensuctl create -f sensu-perl-runtime-5.34.0-debian.json
    ```
 
 4. Create a second asset containing a Perl script.
@@ -156,7 +170,7 @@ Please note the following instructions:
      },
      "spec": {
        "command": "helloworld.pl",
-       "runtime_assets": ["sensu-perl-runtime-5.30.1-debian", "helloworld-v0.1"],
+       "runtime_assets": ["sensu-perl-runtime-5.34.0-debian", "helloworld-v0.1"],
        "publish": true,
        "interval": 10,
        "subscriptions": ["docker"]

--- a/build_and_test_platform.sh
+++ b/build_and_test_platform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ignore_errors=0
-perl_version=5.30.1
+perl_version=5.34.0
 asset_version=${TRAVIS_TAG:-local-build}
 asset_filename=sensu-perl-runtime_${asset_version}_perl-${perl_version}_${platform}_linux_amd64.tar.gz
 asset_image=sensu-perl-runtime-${perl_version}-${platform}:${asset_version}


### PR DESCRIPTION
Hello @nixwiz,

Could you please take a look at this pull request ?
I have added an option to build NET-SNMP with its Perl modules in the runtime along with Perl. This is very useful for instance to execute the [centreon-plugins](https://github.com/centreon/centreon-plugins) which require net-snmp.

I did not include `make test` for the build of net-snmp, because with the option `--disable-agent`, many tests are failing. And agent is not needed for this runtime.

I also changed the default Perl version to 5.34.0
I also added the CPAN modules `File::Slurp` `JSON::XS`
I tested it only with CentOS7
I did not update the build scripts

Let me know if you like it and if you have any comments.

Cheers